### PR TITLE
Change TimeMsg hold time to cover time slot delays

### DIFF
--- a/DAPNETGateway.cpp
+++ b/DAPNETGateway.cpp
@@ -69,7 +69,7 @@ const unsigned char FUNCTIONAL_ALERT1       = 1U;
 const unsigned char FUNCTIONAL_ALERT2       = 2U;
 const unsigned char FUNCTIONAL_ALPHANUMERIC = 3U;
 
-const unsigned int MAX_TIME_TO_HOLD_TIME_MESSAGES = 2000U;		// 2s
+const unsigned int MAX_TIME_TO_HOLD_TIME_MESSAGES = 30000U;		// 30s
 
 int main(int argc, char** argv)
 {


### PR DESCRIPTION
Depending on the time slot configuration, a MAX_TIME_TO_HOLD_TIME_MESSAGES of 2s leads mostly to rejected time msgs. As most of the available pagers display time hours and minutes only, hold time for time msgs may be increased to 30s to assure the time msgs will survive until the next free TX time slot occurs.