### PR TITLE
Moved Flo's variable delay code to recover() to prevent re-logins at f…

### DIFF
--- a/DAPNETGateway.cpp
+++ b/DAPNETGateway.cpp
@@ -407,7 +407,7 @@ void CDAPNETGateway::sendMessages()
 
 bool CDAPNETGateway::recover()
 {
-	const unsigned int backoff[] = {2000u, 4000u, 8000u, 10000, 20000u, 60000u, 120000u, 240000u, 480000u, 600000u};
+	const unsigned int backoff[] = {2000u, 4000u, 8000u, 10000u, 20000u, 60000u, 120000u, 240000u, 480000u, 600000u};
 	int i=0;
 
 	for (;;) {

--- a/DAPNETGateway.cpp
+++ b/DAPNETGateway.cpp
@@ -278,6 +278,9 @@ int CDAPNETGateway::run()
 		}
 
 		bool ok = m_dapnetNetwork->read();
+		if (!ok)
+			recover();
+/*
 		if (!ok) {
 			int i = 0;
 			const unsigned int backoff[] = {
@@ -290,7 +293,7 @@ int CDAPNETGateway::run()
 					i++;
 			}
 		}
-
+*/
 		CPOCSAGMessage* message = m_dapnetNetwork->readMessage();
 		if (message != NULL) {
 			bool found = true;
@@ -404,14 +407,21 @@ void CDAPNETGateway::sendMessages()
 
 bool CDAPNETGateway::recover()
 {
+	const unsigned int backoff[] = {2000u, 4000u, 8000u, 10000, 20000u, 60000u, 120000u, 240000u, 480000u, 600000u};
+	int i=0;
+
 	for (;;) {
 		m_dapnetNetwork->close();
+		CThread::sleep(backoff[i]);
+		
 		bool ok = m_dapnetNetwork->open();
 		if (ok) {
 			ok = m_dapnetNetwork->login();
 			if (ok)
 				return true;
 		}
+		if (i < 9)
+			i++;
 	}
 
 	return false;

--- a/DAPNETNetwork.cpp
+++ b/DAPNETNetwork.cpp
@@ -69,6 +69,8 @@ bool CDAPNETNetwork::read()
 	unsigned char buffer[BUFFER_LENGTH];
 
 	int length = m_socket.read(buffer, BUFFER_LENGTH, 0U);
+	if (length < 0)
+		LogMessage ("socket.read: received error %d", length);
 	if (length == -1)		// Error
 		return false;
 	if (length == -2)		// Connection lost


### PR DESCRIPTION
…ull speed

Hi Jonathan,

FL0's patch as of yesterday didn't work as expected.
I found the recover() function to be responsible for the full-speed re-logins to the core server in case of a network error or even when the login credentials are wrong.
Could you please verify and merge my fix attempt to make all the DAPNETGateway systems been updated soon?

Tnx and 73 de Bert, DD5XL

