### PR TITLE
Adding DebugLog entry for Queue size

### DIFF
--- a/DAPNETGateway.cpp
+++ b/DAPNETGateway.cpp
@@ -362,6 +362,7 @@ int CDAPNETGateway::run()
 				}
 
 				m_queue.push_front(message);
+				LogDebug("Messages in Queue %04u", m_queue.size());
 			}
 		}
 


### PR DESCRIPTION
Hi, 
in order to get the queue size on the dashboard or any other debug system I added one line to add a DebugLog message after each new message in the queue.