### PR TITLE
Add #if block to exclude REGEX loading for old versions of GCC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC      = gcc
 CXX     = g++
-CFLAGS  = -g -O3 -Wall -std=c++0x -pthread
+CFLAGS  = -g -O3 -Wall -std=c++0x -pthread -lrt
 LIBS    = -lm -lpthread
 LDFLAGS = -g
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC      = gcc
 CXX     = g++
-CFLAGS  = -g -O3 -Wall -std=c++0x -pthread -lrt
+CFLAGS  = -g -O3 -Wall -std=c++0x -pthread
 LIBS    = -lm -lpthread
 LDFLAGS = -g
 

--- a/REGEX.cpp
+++ b/REGEX.cpp
@@ -24,6 +24,7 @@
 #include <cstdio>
 #include <cstring>
 
+
 CREGEX::CREGEX(const std::string& regexFile) :
 m_regexFile(regexFile),
 m_regex()
@@ -32,6 +33,13 @@ m_regex()
 
 bool CREGEX::load()
 {
+#if defined(__GNUC__) && (__GNUC__ <= 4) || (__GNUC__ == 4 && __GNUC_MINOR__ <= 9)
+	LogError("REGEX is not properly supported in GCC vesions below 4.9. Not loading REGEX");
+	return false;
+}
+#else
+
+	
 	FILE* fp = ::fopen(m_regexFile.c_str(), "rt");
 	if (fp != NULL) {
 		char buffer[100U];
@@ -67,6 +75,8 @@ bool CREGEX::load()
 
 	return true;
 }
+
+#endif
 
 std::vector<std::regex>  CREGEX::get()
 {

--- a/REGEX.cpp
+++ b/REGEX.cpp
@@ -32,6 +32,11 @@ m_regex()
 }
 
 bool CREGEX::load()
+/* Older versions of GCC appear to support REGEX but silently fail to match. Even
+ * though the headers exist and the code compiles and runs cleanly. The below #if block 
+ * stops the REGEXs being loaded in these cases, effectively disabling REGEX functionality. 
+ * The loading code is replaced with a log entry to show the user this has happened.
+*/
 {
 #if defined(__GNUC__) && (__GNUC__ <= 4) || (__GNUC__ == 4 && __GNUC_MINOR__ <= 9)
 	LogError("REGEX is not properly supported in GCC vesions below 4.9. Not loading REGEX");


### PR DESCRIPTION
Older versions of GCC appear to support REGEX but silently fail to match. Even
 though the headers exist and the code compiles and runs cleanly. The inserted #if block 
 stops the REGEXs being loaded in these cases, effectively disabling REGEX functionality. 
  The loading code is replaced with a call to LogError() to show the user this has happened.

This one took me a little while to track down. The inserted code saves others this pain.
