### PR TITLE
add OpenBSD support and fix sudden death at std::string messageBody()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-CC      = gcc
-CXX     = g++
+CC      = cc
+CXX     = c++
 CFLAGS  = -g -O3 -Wall -std=c++0x -pthread
 LIBS    = -lm -lpthread
 LDFLAGS = -g

--- a/POCSAGMessage.cpp
+++ b/POCSAGMessage.cpp
@@ -34,8 +34,10 @@ m_timeQueued()
 	assert(message != NULL);
 	assert(length > 0U);
 
-	m_message = new unsigned char[length];
+	m_message = new unsigned char[length + 1];
+
 	::memcpy(m_message, message, length);
+	m_message[length] = '\0';
 
 	m_timeQueued.start();
 }


### PR DESCRIPTION
Fixed Makefile for OpenBSD. Use cc instead of gcc to support Clang.

And sometimes DAPNETGateway suddenly stops with core dump.
I found that std::string  messageBody(reinterpret_cast<char*>
(message->m_message)) in DAPNETGateway.cpp calls strlen()
and it causes SIGSEGV.

Here is a memory dump when SIGSEGV occured.
address 0xe788848efe0 is a pointer of message->m_message.
```
(gdb) x/512c 0xe788848efe0
0xe788848efe0:  88 'X'  84 'T'  73 'I'  77 'M'  69 'E'  61 '='  49 '1'  51 '3'
0xe788848efe8:  49 '1'  50 '2'  50 '2'  48 '0'  48 '0'  57 '9'  49 '1'  57 '9'
0xe788848eff0:  88 'X'  84 'T'  73 'I'  77 'M'  69 'E'  61 '='  49 '1'  51 '3'
0xe788848eff8:  49 '1'  50 '2'  50 '2'  48 '0'  48 '0'  57 '9'  49 '1'  57 '9'
0xe788848f000:  Cannot access memory at address 0xe788848f000
(gdb)
```
It looks no '\0' terminated, so I tweaked POCSAGMessage.cpp to add
terminate character.