### PR TITLE
Update Conf.cpp

### DIFF
--- a/Conf.cpp
+++ b/Conf.cpp
@@ -23,6 +23,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <cctype>
+#include <cstdint>
 
 const int BUFFER_SIZE = 500;
 


### PR DESCRIPTION
Fix a compile failure:

# make clean && make
rm -f DAPNETGateway *.o *.d *.bak *~
echo "const char *gitversion = \"b06e6b088bd04bce0edc6d84e98a5656aa3cf127\";" > GitVersion.h
c++ -g -O3 -Wall -DHAVE_LOG_H -std=c++0x -pthread -c -o Conf.o Conf.cpp
Conf.cpp:188:13: error: 'uint32_t' was not declared in this scope
  188 | std::vector<uint32_t> CConf::getWhiteList() const
      |             ^~~~~~~~
Conf.cpp:26:1: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   25 | #include <cctype>
  +++ |+#include <cstdint>
   26 | 
Conf.cpp:188:21: error: template argument 1 is invalid
  188 | std::vector<uint32_t> CConf::getWhiteList() const
      |                     ^
Conf.cpp:188:21: error: template argument 2 is invalid
Conf.cpp:188:23: error: no declaration matches 'int CConf::getWhiteList() const'
  188 | std::vector<uint32_t> CConf::getWhiteList() const
      |                       ^~~~~
In file included from Conf.cpp:19:
Conf.h:35:29: note: candidate is: 'std::vector<unsigned int> CConf::getWhiteList() const'
   35 |   std::vector<unsigned int> getWhiteList() const;
      |                             ^~~~~~~~~~~~
Conf.h:25:7: note: 'class CConf' defined here
   25 | class CConf
      |       ^~~~~
Conf.cpp:193:13: error: 'uint32_t' was not declared in this scope
  193 | std::vector<uint32_t> CConf::getBlackList() const
      |             ^~~~~~~~
Conf.cpp:193:13: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
Conf.cpp:193:21: error: template argument 1 is invalid
  193 | std::vector<uint32_t> CConf::getBlackList() const
      |                     ^
Conf.cpp:193:21: error: template argument 2 is invalid
Conf.cpp:193:23: error: no declaration matches 'int CConf::getBlackList() const'
  193 | std::vector<uint32_t> CConf::getBlackList() const
      |                       ^~~~~
Conf.h:36:29: note: candidate is: 'std::vector<unsigned int> CConf::getBlackList() const'
   36 |   std::vector<unsigned int> getBlackList() const;
      |                             ^~~~~~~~~~~~
Conf.h:25:7: note: 'class CConf' defined here
   25 | class CConf
      |       ^~~~~
make: *** [Makefile:15: Conf.o] Error 1